### PR TITLE
Use orm.em to get EntityManager if present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "silex/silex": "~1.0",
         "symfony/console": "~2.3",
         "doctrine/dbal": "2.2.*",
-        "doctrine/migrations": "1.0.*@dev"
+        "doctrine/migrations": "1.0.*@dev",
+        "doctrine/orm": "~2.2"
     },
     "autoload": {
         "psr-0": { "": "src/" }

--- a/src/Kurl/Silex/Provider/DoctrineMigrationsProvider.php
+++ b/src/Kurl/Silex/Provider/DoctrineMigrationsProvider.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Console\Application as Console;
@@ -78,15 +79,16 @@ class DoctrineMigrationsProvider implements ServiceProviderInterface
      */
     public function boot(Application $app)
     {
-        $this->console->setHelperSet(
-            new HelperSet(
-                array(
-                    'connection' => new ConnectionHelper($app['db']),
-                    'dialog'     => new DialogHelper(),
-                    //'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($em)
-                )
-            )
-        );
+        $helperSet = new HelperSet(array(
+            'connection' => new ConnectionHelper($app['db']),
+            'dialog'     => new DialogHelper(),
+        ));
+
+        if (isset($app['orm.em'])) {
+            $helperSet->set(new EntityManagerHelper($app['orm.em']), 'em');
+        }
+
+        $this->console->setHelperSet($helperSet);
 
         $commands = array(
             'Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand',

--- a/tests/Kurl/Silex/Provider/Tests/DoctrineMigrationsProviderTest.php
+++ b/tests/Kurl/Silex/Provider/Tests/DoctrineMigrationsProviderTest.php
@@ -17,11 +17,13 @@ use Symfony\Component\Console\Application as Console;
  * Class DoctrineMigrationsProviderTest
  *
  * @package Kurl\Silex\Provider\Tests
+ * @coversDefaultClass Kurl\Silex\Provider\DoctrineMigrationsProvider
  */
 class DoctrineMigrationsProviderTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * Basic sanity checks.
+     * @covers ::register
+     * @covers ::boot
      */
     public function testDefaults()
     {
@@ -44,6 +46,7 @@ class DoctrineMigrationsProviderTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($console->has('migrations:migrate'));
         $this->assertFalse($console->has('migrations:status'));
         $this->assertFalse($console->has('migrations:version'));
+        $this->assertFalse($console->has('migrations:diff'));
 
         $app->boot();
 
@@ -52,5 +55,35 @@ class DoctrineMigrationsProviderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($console->has('migrations:migrate'));
         $this->assertTrue($console->has('migrations:status'));
         $this->assertTrue($console->has('migrations:version'));
+        $this->assertFalse($console->has('migrations:diff'));
+    }
+
+    /**
+     * @covers ::boot
+     */
+    public function testDefaultsWithOrm()
+    {
+        $app = new Silex();
+        $app['db'] = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $app['orm.em'] = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+
+        $console = new Console();
+        $app->register(new DoctrineMigrationsProvider($console));
+
+        $this->assertFalse($console->has('migrations:execute'));
+        $this->assertFalse($console->has('migrations:generate'));
+        $this->assertFalse($console->has('migrations:migrate'));
+        $this->assertFalse($console->has('migrations:status'));
+        $this->assertFalse($console->has('migrations:version'));
+        $this->assertFalse($console->has('migrations:diff'));
+
+        $app->boot();
+
+        $this->assertTrue($console->has('migrations:execute'));
+        $this->assertTrue($console->has('migrations:generate'));
+        $this->assertTrue($console->has('migrations:migrate'));
+        $this->assertTrue($console->has('migrations:status'));
+        $this->assertTrue($console->has('migrations:version'));
+        $this->assertTrue($console->has('migrations:diff'));
     }
 }


### PR DESCRIPTION
I am not sure if this is the really correct way, but I've tried
to follow the conventions I could infer.

I think `orm.em` is the accepted convention to store the Entity manager,
but I don't really like relying on these undocumented strings.

Anyways, this works and is better than the previous commented code.

I hope you'd be able to improve it in the future.
