### PR TITLE
Prevent override of default Symfony Console helper set

### DIFF
--- a/src/DoctrineMigrationsProvider.php
+++ b/src/DoctrineMigrationsProvider.php
@@ -148,7 +148,14 @@ class DoctrineMigrationsProvider implements
         $console = $this->getConsole($app);
 
         if ($console) {
-            $console->setHelperSet($app['migrations.em_helper_set']);
+            $helperSet = $console->getHelperSet();
+
+            foreach ($app['migrations.em_helper_set'] as $name => $helper) {
+                if (false === $helperSet->has($name)) {
+                    $helperSet->set($helper, $name);
+                }
+            }
+
             $console->addCommands($app['migrations.commands']);
         }
     }


### PR DESCRIPTION
I find this service provider really useful for quickly getting Doctrine Migrations integrated into my Silex projects, and I was looking for an easy way to retain the default helper sets of Symfony Console, while still booting up a Console Application like this:

```
$app = new Silex\Application();
$console = new Symfony\Component\Console\Application();

// register Silex service providers
// register Symfony Console commands

$app->boot();
$console->run();
```

Do you think a change like this would make any sense (to append helper sets, rather than override them) or not at all?
