### PR TITLE
You can pass an optional instance of Symfony\Component\Console\Applic…

### DIFF
--- a/src/Kurl/Silex/Provider/DoctrineMigrationsProvider.php
+++ b/src/Kurl/Silex/Provider/DoctrineMigrationsProvider.php
@@ -40,7 +40,7 @@ class DoctrineMigrationsProvider implements ServiceProviderInterface
      *
      * @param Console $console
      */
-    public function __construct(Console $console)
+    public function __construct(Console $console = null)
     {
         $this->console = $console;
     }
@@ -88,7 +88,9 @@ class DoctrineMigrationsProvider implements ServiceProviderInterface
             $helperSet->set(new EntityManagerHelper($app['orm.em']), 'em');
         }
 
-        $this->console->setHelperSet($helperSet);
+        $console = $this->getConsole($app);
+
+        $console->setHelperSet($helperSet);
 
         $commands = array(
             'Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand',
@@ -99,7 +101,7 @@ class DoctrineMigrationsProvider implements ServiceProviderInterface
         );
 
         // @codeCoverageIgnoreStart
-        if (true === $this->console->getHelperSet()->has('em')) {
+        if (true === $console->getHelperSet()->has('em')) {
             $commands[] = 'Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand';
         }
         // @codeCoverageIgnoreEnd
@@ -117,7 +119,18 @@ class DoctrineMigrationsProvider implements ServiceProviderInterface
             /** @var AbstractCommand $command */
             $command = new $name();
             $command->setMigrationConfiguration($configuration);
-            $this->console->add($command);
+            $console->add($command);
         }
+    }
+
+    /**
+     * Gets the console application.
+     *
+     * @param Application $app
+     * @return Console|null
+     */
+    public function getConsole(Application $app = null)
+    {
+        return $this->console ?: ((isset($app['console'])) ? $app['console'] : new Console());
     }
 }

--- a/tests/Kurl/Silex/Provider/Tests/DoctrineMigrationsProviderTest.php
+++ b/tests/Kurl/Silex/Provider/Tests/DoctrineMigrationsProviderTest.php
@@ -8,10 +8,14 @@
 
 namespace Kurl\Silex\Provider\Tests;
 
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\OutputWriter;
 use Kurl\Silex\Provider\DoctrineMigrationsProvider;
 use PHPUnit_Framework_TestCase;
 use Silex\Application as Silex;
 use Symfony\Component\Console\Application as Console;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Class DoctrineMigrationsProviderTest
@@ -91,5 +95,14 @@ class DoctrineMigrationsProviderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($console->has('migrations:status'));
         $this->assertTrue($console->has('migrations:version'));
         $this->assertTrue($console->has('migrations:diff'));
+    }
+
+    /**
+     * Ensures you get a console even if you don't set one.
+     */
+    public function testOptionalConsoleConstructor()
+    {
+        $provider = new DoctrineMigrationsProvider();
+        $this->assertInstanceOf(Console::class, $provider->getConsole());
     }
 }


### PR DESCRIPTION
SILEX v1: You can pass an optional instance of Symfony\Component\Console\Application to the constructor of the provider. Alternatively you can set the instance of your Console application to $app['console']. If the provider can find the Console application instance it is able to register the commands and helper set for you.